### PR TITLE
feat: add release notes for Beta-0.3.0 and document Rigging module

### DIFF
--- a/src/content/docs/changelog/Beta-0.2.0.md
+++ b/src/content/docs/changelog/Beta-0.2.0.md
@@ -4,9 +4,6 @@ description: Release Notes for Beta-0.2.0
 lastUpdated: 2025-18-06
 sidebar:
   order: 3
-  badge:
-    text: Current
-    variant: success
 ---
 
 **Release Date:** June 18, 2025

--- a/src/content/docs/changelog/beta-0.3.0.md
+++ b/src/content/docs/changelog/beta-0.3.0.md
@@ -1,0 +1,39 @@
+---
+title: Beta-0.3.0
+description: Release Notes for Beta-0.3.0
+lastUpdated: 2025-18-06
+sidebar:
+  order: 4
+  badge:
+    text: Current
+    variant: success
+---
+
+**Release Date:** July 2, 2025
+
+This release introduces the new **Rigging module**, expanding the BackOps advancing system to support rigging-specific needs for artists and production teams.
+
+## 🎯 New Features
+
+- **Rigging Module (Artist Advancing)**  
+  A dedicated advancing module for managing rigging needs—collecting essential information such as item name, description, stage location, and total weight.
+- **Approval Flow for Rigging Requests**  
+  Rigging requests now follow a structured approval process, ensuring that all flown elements are reviewed and approved before showtime.
+
+- **Line Items & Procurement Integration**  
+  Users can specify which support gear (e.g., motors, truss) they need provided. These requests move into the resource approval pipeline and follow the same procurement path as other modules.
+
+- **Rigging Notes Field**  
+  Collaborators can add detailed notes or context, such as timing, rigging order of operations, or shared usage details.
+
+- **Rigging Plans Upload**  
+  Attach rigging drawings or structural diagrams directly to your rigging requests, providing technical documentation alongside request details.
+
+## 🧰 Use Case Examples
+
+- Artists can now submit rigging requests like “Upstage Softgoods” and request the house to provide four 10' truss sections and two 1-ton motors.
+- Production can review all rigging weights and locations to plan load distribution and labor accordingly.
+- Rigging drawings attached to requests help on-site teams prepare for safe and efficient installations.
+- House teams can fulfill requested rigging gear through the same procurement and orders workflow already used in other modules.
+
+This release marks another step in making BackOps a full-service advancing and logistics platform. As always, feedback is welcome as we continue to iterate.

--- a/src/content/docs/modules/rigging.md
+++ b/src/content/docs/modules/rigging.md
@@ -1,0 +1,33 @@
+---
+title: Rigging
+description: Talks through the Rigging Module
+lastUpdated: 2025-06-28
+---
+
+The **Rigging module** is an **area module** used during artist advancing to request permission for rigging equipment in specific stage areas. This includes collecting details about what is being rigged, where it is going, and how much it weighs. Each rigging request also allows collaborators to specify whether support gear (e.g., truss or motors) needs to be provided by the event team.
+
+Rigging requests go through an **approval process**, ensuring that each item is safe, permitted, and appropriately resourced. Any gear requested under a rigging item becomes part of the **resource approval** and **procurement** flows.
+
+---
+
+## Fields
+
+| Field            | Description                                                                                                                                     | Type                |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| **Name**         | The label for the rigging request. Often describes the item being flown (e.g., “Upstage Softgoods Truss”).                                      | Free Text           |
+| **Description**  | Detailed explanation of what’s being rigged and its purpose.                                                                                    | Free Text           |
+| **Location**     | The desired rigging location on stage (e.g., “USC” for Upstage Center, or “DSR” for Downstage Right).                                           | Free Text           |
+| **Weight**       | Total weight of the rigged element, for structural load planning.                                                                               | Free Text           |
+| **Rigging Plan** | File uplaod of the relevant rigging drawing.                                                                                                    | File                |
+| **Line Items**   | A list of gear that must be **provided by the event team** to support the rigging request (e.g., motors, truss). These items go to procurement. | Resource Line Items |
+| **Notes**        | General notes related to rigging needs—can include timing, coordination details, or special warnings.                                           | Free Text           |
+
+> 💡 _Line Items requested here will be routed through the procurement process and must receive resource approval before being fulfilled._
+
+---
+
+## Use Cases
+
+- An artist requests a 40' upstage truss to hang softgoods, notes the weight as 650 lbs, and asks the house to provide motors and truss.
+- A tour brings their own rigging package but still submits requests to document rigging locations and confirm approval.
+- A production adds house truss and rigging to the artist’s plan, assigning it for procurement in the resource approval process.


### PR DESCRIPTION
This pull request introduces the new Rigging module and updates documentation to reflect its features and functionality. It also includes changes to the changelog files to document the release of Beta-0.3.0. The most important updates are the addition of the Rigging module documentation, new features in Beta-0.3.0, and adjustments to the changelog structure.

### Rigging Module Documentation:
* Added `src/content/docs/modules/rigging.md` to provide comprehensive details about the Rigging module, including its purpose, fields, and use cases. The module supports artist advancing by managing rigging requests and integrating them into approval and procurement workflows.

### Beta-0.3.0 Release Notes:
* Added `src/content/docs/changelog/beta-0.3.0.md` outlining new features such as the Rigging module, approval flow for rigging requests, procurement integration, and rigging plans upload. Use case examples are also provided to illustrate real-world applications.

### Changelog Updates:
* Removed the "Current" badge from Beta-0.2.0 in `src/content/docs/changelog/Beta-0.2.0.md` to reflect its status as a previous release.